### PR TITLE
朝活開始ボタン押下後　追加

### DIFF
--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -1,8 +1,18 @@
 class MorningActivityLogsController < ApplicationController
     def index
+        @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
     end
 
-    def new
-    end
+    def create
+        @morning_activity_log = current_user.morning_activity_logs.new(started_time: Time.now)
+        @morning_activity_log.start_time_plan = current_user.start_time_plan
+     
+       if @morning_activity_log.save
+         flash[:success] = '朝活を開始しました'
+       else
+         flash[:error] = '朝活を開始できませんでした'
+       end
+       redirect_to morning_activity_logs_path
+     end
 
 end


### PR DESCRIPTION
## 概要

issue番号 #56 

## 確認方法
- [ ] bin/dev
- [ ] localhost:3000にアクセス
- [ ] ログイン→morning_activity_logs画面へ遷移
- [ ] 目標朝活開始時刻で時刻を設定
- [ ] 更新（もしくは「設定する」）→ morning_activity_logs画面へ遷移
- [ ] 新規登録後・ゲストログイン後も同様に遷移
