### PR TITLE
朝活達成カウント機能の作成

### DIFF
--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -1,6 +1,7 @@
 class MorningActivityLogsController < ApplicationController
     def index
         @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
+        @achieved_count = current_user.morning_activity_logs.count
     end
 
     def create

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -1,7 +1,7 @@
 class MorningActivityLogsController < ApplicationController
     def index
         @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
-        @achieved_count = current_user.morning_activity_logs.count
+        @achieved_count = @morning_activity_logs.select(&:achieved?).count
     end
 
     def create

--- a/app/models/morning_activity_log.rb
+++ b/app/models/morning_activity_log.rb
@@ -22,4 +22,16 @@
 class MorningActivityLog < ApplicationRecord
   belongs_to :user
   belongs_to :start_time_plan
+
+  ALLOWED_START_TIME = Time.zone.parse("03:00:00")
+  ALLOWED_END_OFFSET = 59.seconds
+
+  def achieved?
+    return false if started_time.blank? || start_time_plan.blank?
+  
+    allowed_start_time = start_time_plan.start_time.change(hour: ALLOWED_START_TIME.hour, min: ALLOWED_START_TIME.min, sec: ALLOWED_START_TIME.sec)
+    allowed_end_time = start_time_plan.start_time + ALLOWED_END_OFFSET
+  
+    (started_time >= allowed_start_time) && (started_time <= allowed_end_time)
+  end
 end

--- a/app/views/morning_activity_logs/index.html.erb
+++ b/app/views/morning_activity_logs/index.html.erb
@@ -12,10 +12,10 @@
             <div class="flex flex-col items-center">
               <%= render partial: 'start_time_plans/start_time' %>
             </div>
-            <%= form_with(model: @morning_activity_log, url: morning_activity_logs_path, local: true) do |form| %>
+            <%= form_with(model: @morning_activity_log, url: morning_activity_logs_path, local: true) do |f| %>
                 <div class="flex flex-col gap-4 p-4 md:p-8">
-                <%= form.hidden_field :started_time %>
-                  <%= form.submit "朝活開始", class: 'btn btn-primary inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base' %>
+                <%= f.hidden_field :started_time %>
+                  <%= f.submit "朝活開始", class: 'btn btn-primary inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base' %>
                 </div>
               <% end %>
           </div>

--- a/app/views/morning_activity_logs/index.html.erb
+++ b/app/views/morning_activity_logs/index.html.erb
@@ -7,7 +7,7 @@
             <div class="flex flex-col items-center">
               <h1>朝活達成状況</h1>
               <p>達成回数</p> 
-              <%=  %>
+              <%= @achieved_count %>
             </div>
             <div class="flex flex-col items-center">
               <%= render partial: 'start_time_plans/start_time' %>

--- a/app/views/start_time_plans/_form.html.erb
+++ b/app/views/start_time_plans/_form.html.erb
@@ -8,5 +8,5 @@
   <%= f.label :start_time, t('start_time_plans.title') %>
 </div>
 <div class="flex flex-col items-center">
-  <%= f.time_field :start_time, class: 'form-control', min: '3:00', max: '10:00' %>
+  <%= f.time_field :start_time, class: 'form-control', min: '4:00', max: '10:00' %>
 </div>


### PR DESCRIPTION
## 概要

issue番号 #59 

## 確認方法
- [ ] bin/dev
- [ ] localhost:3000にアクセス
- [ ] ログイン→morning_activity_logs画面へ遷移
- [ ] 目標朝活開始時刻で時刻を設定
- [ ] 更新（もしくは「設定する」）→ morning_activity_logs画面へ遷移
- [ ] 朝活開始ボタンを押下
- [ ] 目標開始時刻より前の時刻押下でカウント（すぎた場合は開始時刻はDBに保存されるが、カウントはノーカウント）

