### PR TITLE
目標朝活開始時間内　成功表示

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,7 @@
 exit
+@achieved_count
+@previous_achieved_count
+exit
 user.monthly_achievements.find_or_initialize_by(month: Time.current.month, year: Time.current.year)
 exit
 @morning_activity_log.started_time

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,6 @@
 exit
+user.monthly_achievements.find_or_initialize_by(month: Time.current.month, year: Time.current.year)
+exit
 @morning_activity_log.started_time
 @morning_activity_log 
 exit

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,3 +3,4 @@
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds
+//= link morning_activity_logs.js

--- a/app/assets/javascripts/morning_activity_logs.js
+++ b/app/assets/javascripts/morning_activity_logs.js
@@ -1,0 +1,124 @@
+const MODAL_DISPLAY_TRUE = 'true';
+const HIDDEN_CLASS = 'hidden';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('modal');
+  const closeModalButton = document.getElementById('close-modal');
+
+  // クエリパラメーターから "achieved" を取得
+  const params = new URLSearchParams(window.location.search);
+  const achieved = params.get('achieved');
+
+  const achievedCount = parseInt(modal.dataset.achievedCount);
+  const previousAchievedCount = parseInt(modal.dataset.previousAchievedCount);
+  const currentMonth = new Date().getMonth() + 1;
+
+  const firstTimeMessage = 'おめでとうございます！今月初めての朝活成功をしました！これからも継続して朝活を行い、目標達成に向けて一緒に頑張りましょう！素晴らしいスタートですね！';
+
+  // ランダムなメッセージリスト
+  const randomMessages = generateRandomMessages(currentMonth, achievedCount);
+
+  // 朝活達成時の処理
+  if (achieved === MODAL_DISPLAY_TRUE) {
+    displayAchievementMessage(modal, previousAchievedCount, achievedCount, firstTimeMessage, randomMessages);
+  }
+
+  // モーダルを閉じるイベントリスナー
+  closeModalButton.addEventListener('click', () => {
+    closeModalAndUpdateUrl(modal, params);
+  });
+});
+
+
+// ランダムなメッセージリストを生成する関数
+function generateRandomMessages(currentMonth, achievedCount) {
+  
+  // メッセージの定義
+  const messages = [
+  `すごい！${currentMonth}月は既に${achievedCount}日間朝活に成功しています！この調子で前進しましょう！`,
+    `お見事！${currentMonth}月は今日で${achievedCount}日朝活成功です！目標達成まであと一息ですね！`,
+    `素晴らしい成果！${currentMonth}月はこれで${achievedCount}日間朝活成功！さらなる高みを目指しましょう！`,
+    `すごい！${currentMonth}月は既に${achievedCount}日間朝活に成功しています！この調子で前進しましょう！`,
+    `素晴らしい成果！${currentMonth}月はこれで${achievedCount}日間朝活成功！さらなる高みを目指しましょう！`,
+    `朝活達成${achievedCount}日目！${currentMonth}月も元気にスタート！継続の力を信じて、頑張りましょう！`,
+    `${currentMonth}月は${achievedCount}日間朝活成功！目標を見失わず、一歩一歩進みましょう！`,
+    `${currentMonth}月はすでに${achievedCount}日間朝活達成！このまま続けて、目標をクリアしましょう！`,
+    `やりましたね！${currentMonth}月は${achievedCount}日間朝活成功！毎日の努力が確実に成果につながっています！`,
+    `お疲れ様です！${currentMonth}月はこれで${achievedCount}日間朝活達成！持続的な努力が大切ですね！`,
+    `${currentMonth}月は${achievedCount}日間朝活達成！目標達成に向けて、一緒に頑張りましょう！`,
+    `朝活達成率が上がっています！${currentMonth}月はすでに${achievedCount}日間成功！この勢いでさらに頑張りましょう！`,
+
+    `${currentMonth}月も${achievedCount}日間朝活成功！継続していくことで、夢が現実に近づいていきます！`,
+    `すばらしい継続力！${currentMonth}月は${achievedCount}日間朝活達成！一日一日の積み重ねが大切ですね！`,
+    `${currentMonth}月はこれで${achievedCount}日間朝活成功！夢に向かって邁進しましょう！`,
+    `お疲れ様です！${currentMonth}月も${achievedCount}日間朝活達成！自分へのご褒美を忘れずに！`,
+`${currentMonth}月は${achievedCount}日間朝活成功！一歩ずつでも確実に進んでいます！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！素晴らしい努力を続けましょう！`,
+`朝活達成${achievedCount}日目！${currentMonth}月も絶好調です！引き続き頑張りましょう！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！努力が実り、大きな成果へと繋がります！`,
+`${currentMonth}月は${achievedCount}日間朝活達成！継続は力なり、素晴らしい成果を生み出します！`,
+`${currentMonth}月も${achievedCount}日間朝活成功！自分を信じて、目標に向かって進みましょう！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活達成！勇敢なあなたを称えましょう！`,
+
+`やりましたね！${currentMonth}月は${achievedCount}日間朝活成功！自分に自信を持ち、さらなる高みへ！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！素晴らしい継続力が明るい未来を切り開きます！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！あなたの努力は大きな変化を生み出しています！`,
+`おめでとう！${currentMonth}月は${achievedCount}日間朝活達成！毎日のチャレンジがあなたを成長させます！`,
+`${currentMonth}月も${achievedCount}日間朝活成功！このままのペースで前進し続けましょう！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活達成！あなたの努力は周りにも良い影響を与えます！`,
+`${currentMonth}月は${achievedCount}日間朝活成功！自分を褒めて、エネルギーをチャージしましょう！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！継続していくことで、無限の可能性が広がります！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！進む道を信じて、躍進しましょう！`,
+`お疲れ様です！${currentMonth}月は${achievedCount}日間朝活達成！この調子で明日も頑張りましょう！`,
+
+`すばらしい！${currentMonth}月は${achievedCount}日間朝活成功！毎日の小さな努力があなたの力になります！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！あなたの努力は素晴らしい成果をもたらします！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！継続することで、新たな目標に挑戦できます！`,
+`努力が報われました！${currentMonth}月は${achievedCount}日間朝活達成！あなたの頑張りに敬意を表します！`,
+`${currentMonth}月も${achievedCount}日間朝活成功！一つひとつの達成が、あなたの自信につながります！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活達成！あなたの持続力は素晴らしい成長をもたらします！`,
+`${currentMonth}月は${achievedCount}日間朝活成功！継続することで、あなたの可能性は無限に広がります！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！あなたの努力は人生をより豊かにします！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！目標達成への道は一歩ずつ進むことが大切です！`,
+`素晴らしい！${currentMonth}月は${achievedCount}日間朝活達成！この調子でさらなる目標にチャレンジしましょう！`,
+
+`やり遂げました！${currentMonth}月は${achievedCount}日間朝活成功！あなたの成長を感じる瞬間です！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！あなたの意志力が次のステップへと導きます！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！毎日の継続があなたを強くします！`,
+`素晴らしい努力！${currentMonth}月は${achievedCount}日間朝活達成！あなたのパワーは限界を超えています！`,
+`${currentMonth}月も${achievedCount}日間朝活成功！あなたの活力が周りにも伝染し、みんなを元気にします！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活達成！あなたの情熱が大きなインパクトを生み出します！`,
+`朝活達成で${currentMonth}月は${achievedCount}日間成功！あなたの素晴らしい継続力を讃えましょう！`,
+
+`おめでとうございます！${currentMonth}月は${achievedCount}日間朝活達成！あなたの努力は目標に近づく力になります！`,
+`${currentMonth}月も${achievedCount}日間朝活成功！あなたの決断力が素晴らしい成果を生んでいます！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活達成！あなたの継続力が新たな扉を開きます！`,
+`素晴らしい達成感！${currentMonth}月は${achievedCount}日間朝活成功！あなたの前途は明るく輝いています！`,
+`${currentMonth}月も${achievedCount}日間朝活達成！あなたの行動力が新しい道へと導いてくれます！`,
+`${currentMonth}月はこれで${achievedCount}日間朝活成功！あなたの勇敢な姿勢が大きな成果を引き寄せます！`,
+`すごい！！朝活達成！${currentMonth}月は${achievedCount}日間成功！あなたの行動力が夢を現実にします！`
+  ];
+  return messages;
+}
+
+// 朝活達成時のメッセージを表示する関数
+function displayAchievementMessage(modal, previousAchievedCount, achievedCount, firstTimeMessage, randomMessages) {
+  if (previousAchievedCount === 0 && achievedCount === 1) {
+    console.log('Displaying first time message');
+    document.getElementById("modal-content").innerHTML = firstTimeMessage;
+  } else {
+    console.log('Displaying random message');
+    const randomIndex = Math.floor(Math.random() * randomMessages.length);
+    document.getElementById("modal-content").innerHTML = randomMessages[randomIndex];
+  }
+  modal.classList.remove(HIDDEN_CLASS);
+}
+
+// モーダルを閉じてURLを更新する関数
+function closeModalAndUpdateUrl(modal, params) {
+  modal.classList.add(HIDDEN_CLASS);
+
+  // クエリパラメーター "achieved" を削除し、ページ URL を更新
+  params.delete('achieved');
+  window.history.replaceState({}, '', `${location.pathname}?${params}`);
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
   before_action :require_login
   add_flash_types :success, :info, :warning, :error
+
+  private
+
+  def not_authenticated
+    flash[:error] = 'ログインしてください'
+    redirect_to login_url
+  end
 end

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -1,6 +1,6 @@
 class MorningActivityLogsController < ApplicationController
   before_action :require_login
-  DISALLOWED_HOUR = 3
+  
 
   def index
     @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
@@ -10,7 +10,7 @@ class MorningActivityLogsController < ApplicationController
 
   def create
     #フロントエンドの制御が機能しなかった場合に問題が発生する可能性があるため設置
-    if is_morning_activity_not_allowed?
+    if MorningActivityLog.is_morning_activity_not_allowed?(current_user)
       flash[:error] = t('.is_morning_activity_not_allowed.fail')
       redirect_to morning_activity_logs_path
       return

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -16,15 +16,22 @@ class MorningActivityLogsController < ApplicationController
       return
     end
 
-    @morning_activity_log = current_user.morning_activity_logs.new(started_time: Time.current)
+    @morning_activity_log = current_user.morning_activity_logs.new(start_time_plan_id: params[:start_time_plan_id], started_time: Time.current)
     @morning_activity_log.start_time_plan = current_user.start_time_plan
 
     if @morning_activity_log.save
-      flash[:success] = t('.success')
+      if @morning_activity_log.achieved?
+        MorningActivityLog.current_monthly_achievement(current_user).increment_achieved_count
+        redirect_to morning_activity_logs_path(achieved: 'true')
+        flash[:success] = t('.success')
+      else
+        flash[:success] = t('.success')
+        redirect_to morning_activity_logs_path(achieved: @morning_activity_log.achieved?)
+      end
     else
       flash[:error] = t('.fail')
+      redirect_to morning_activity_logs_path
     end
-    redirect_to morning_activity_logs_path
   end
 
   

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -1,38 +1,29 @@
 class MorningActivityLogsController < ApplicationController
   before_action :require_login
+  DEFAULT_ACHIEVED_COUNT = 0
   
 
   def index
     @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
-    @achieved_count = @morning_activity_logs.select(&:achieved?).count
     @morning_activity_not_allowed = MorningActivityLog.is_morning_activity_not_allowed?(current_user)
+    @previous_achieved_count = [(params[:previous_achieved_count] || MorningActivityLog.current_monthly_achievement(current_user).achieved_count || DEFAULT_ACHIEVED_COUNT).to_i, DEFAULT_ACHIEVED_COUNT].max
+    @achieved_count = [(params[:achieved_count] || MorningActivityLog.current_monthly_achievement(current_user).achieved_count || DEFAULT_ACHIEVED_COUNT).to_i, DEFAULT_ACHIEVED_COUNT].max
   end
-
+  
   def create
-    #フロントエンドの制御が機能しなかった場合に問題が発生する可能性があるため設置
     if MorningActivityLog.is_morning_activity_not_allowed?(current_user)
       flash[:error] = t('.is_morning_activity_not_allowed.fail')
       redirect_to morning_activity_logs_path
       return
     end
-
-    @morning_activity_log = current_user.morning_activity_logs.new(start_time_plan_id: params[:start_time_plan_id], started_time: Time.current)
-    @morning_activity_log.start_time_plan = current_user.start_time_plan
-
-    if @morning_activity_log.save
-      if @morning_activity_log.achieved?
-        MorningActivityLog.current_monthly_achievement(current_user).increment_achieved_count
-        redirect_to morning_activity_logs_path(achieved: 'true')
-        flash[:success] = t('.success')
-      else
-        flash[:success] = t('.success')
-        redirect_to morning_activity_logs_path(achieved: @morning_activity_log.achieved?)
-      end
+  
+    success, redirect_params = MorningActivityLog.create_log_and_check_achievement(current_user, params[:start_time_plan_id])
+    if success
+      flash[:success] = t('.success')
+      redirect_to morning_activity_logs_path(redirect_params)
     else
       flash[:error] = t('.fail')
       redirect_to morning_activity_logs_path
     end
   end
-
-  
 end

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -5,7 +5,7 @@ class MorningActivityLogsController < ApplicationController
   def index
     @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
     @achieved_count = @morning_activity_logs.select(&:achieved?).count
-    @morning_activity_not_allowed = is_morning_activity_not_allowed?
+    @morning_activity_not_allowed = MorningActivityLog.is_morning_activity_not_allowed?(current_user)
   end
 
   def create
@@ -27,16 +27,5 @@ class MorningActivityLogsController < ApplicationController
     redirect_to morning_activity_logs_path
   end
 
-  private
-
-  def is_morning_activity_not_allowed?
-     # 現在の時間が03:00:00よりも前であれば、朝活は許可されていないため、trueを返す
-    return true if Time.current.hour < DISALLOWED_HOUR
-     # 最後に記録された朝活ログを取得する（降順でソートし、最初の要素を取得）
-    last_log = current_user.morning_activity_logs.order(started_time: :desc).first
-    return false if last_log.nil?
-     # 現在の日付と最後に記録された朝活ログの日付が同じであれば、朝活は許可されていないため、trueを返す
-     # それ以外の場合（つまり、最後に記録された朝活ログが前の日である場合）は、朝活が許可されているため、falseを返す
-    Time.current.to_date == last_log.started_time.to_date
-  end
+  
 end

--- a/app/models/monthly_achievement.rb
+++ b/app/models/monthly_achievement.rb
@@ -21,6 +21,7 @@
 class MonthlyAchievement < ApplicationRecord
   belongs_to :user
   INCREMENT_VALUE = 1
+  
 
 # achieved_count に nil が入らないように設定。値が無い場合、to_i メソッドで 0 を返す。加算時には +1 される。
 def increment_achieved_count

--- a/app/models/monthly_achievement.rb
+++ b/app/models/monthly_achievement.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: monthly_achievements
+#
+#  id             :bigint           not null, primary key
+#  achieved_count :integer
+#  month          :integer
+#  year           :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :uuid             not null
+#
+# Indexes
+#
+#  index_monthly_achievements_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class MonthlyAchievement < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/monthly_achievement.rb
+++ b/app/models/monthly_achievement.rb
@@ -20,4 +20,11 @@
 #
 class MonthlyAchievement < ApplicationRecord
   belongs_to :user
+  INCREMENT_VALUE = 1
+
+# achieved_count に nil が入らないように設定。値が無い場合、to_i メソッドで 0 を返す。加算時には +1 される。
+def increment_achieved_count
+    self.achieved_count = achieved_count.to_i + INCREMENT_VALUE
+    save!
+  end
 end

--- a/app/models/morning_activity_log.rb
+++ b/app/models/morning_activity_log.rb
@@ -38,6 +38,12 @@ class MorningActivityLog < ApplicationRecord
     Time.current.to_date == last_log.started_time.to_date
   end
 
+  # 今月の達成状況を取得するメソッド
+def self.current_monthly_achievement(user)
+  user.monthly_achievements.find_or_initialize_by(month: Time.current.month, year: Time.current.year)
+end
+
+
   # 達成したかどうかを判断するメソッド
   def achieved?
     # started_time または start_time_plan が空の場合、達成していないと判断

--- a/app/models/morning_activity_log.rb
+++ b/app/models/morning_activity_log.rb
@@ -30,6 +30,14 @@ class MorningActivityLog < ApplicationRecord
   ALLOWED_START_SEC = 0
   ALLOWED_END_OFFSET = 59.seconds
 
+  # 朝活を許可する時間帯かどうかを判断するメソッド
+  def self.is_morning_activity_not_allowed?(user)
+    return true if Time.current.hour < ALLOWED_START_HOUR
+    last_log = user.morning_activity_logs.order(started_time: :desc).first
+    return false if last_log.nil?
+    Time.current.to_date == last_log.started_time.to_date
+  end
+
   # 達成したかどうかを判断するメソッド
   def achieved?
     # started_time または start_time_plan が空の場合、達成していないと判断

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_one :start_time_plan, dependent: :destroy
   has_many :morning_activity_logs, dependent: :destroy
+  has_many :monthly_achievements
+
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@
 #
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  DEFAULT_ACHIEVED_COUNT = 0
+  
   has_many :posts, dependent: :destroy
   has_one :start_time_plan, dependent: :destroy
   has_many :morning_activity_logs, dependent: :destroy
@@ -31,4 +33,16 @@ class User < ApplicationRecord
   def own?(object)
     id == object.user_id
   end
+
+  # ユーザーの前月の達成数を返すメソッド / もし前月の達成数が存在しない場合、0を返す
+  def previous_achieved_count
+    current_monthly_achievement.try(:achieved_count) || DEFAULT_ACHIEVED_COUNT
+  end
+
+  # ユーザーの現在の月の達成数を返すメソッド / もし現在の月の達成数が存在しない場合、0を返す
+  def current_achieved_count
+    current_monthly_achievement.try(:achieved_count) || DEFAULT_ACHIEVED_COUNT
+  end
+
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Portfolio</title>
+<head>
+    <title>RailsPractice</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -9,8 +9,10 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <link rel="stylesheet" href="./css/tailwind.dist.css?v=1.0">
-  </head>
+    <%= javascript_include_tag 'morning_activity_logs', 'data-turbolinks-track': 'reload' %>
+
+
+</head>
 
   <body>
     <%= render logged_in? ? 'shared/header' : 'shared/before_login_header' %>

--- a/app/views/morning_activity_logs/index.html.erb
+++ b/app/views/morning_activity_logs/index.html.erb
@@ -30,6 +30,8 @@
                 <span class="text-center text-sm font-semibold text-gray-500 md:text-base">早朝3:00までは打刻できません</span>
               </div>
             <% end %>
+            <% display_modal = @achieved_count.to_i > @previous_achieved_count.to_i %>
+            <%= render 'shared/modal', display_modal: display_modal %>
           </div>
         </div>
       </div>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,0 +1,7 @@
+<!-- モーダル -->
+<div id="modal" data-achieved-count="<%= @achieved_count %>" data-previous-achieved-count="<%= @previous_achieved_count %>" class="fixed inset-0 flex items-center justify-center z-50 <%= display_modal ? '' : 'hidden' %>">
+  <div class="bg-white p-6 rounded-lg shadow-lg">
+    <h3 id="modal-content" class="font-bold text-lg"></h3>
+    <button id="close-modal" class="bg-blue-500 text-white px-4 py-2 rounded mt-4">閉じる</button>
+  </div>
+</div>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -5,3 +5,4 @@
     <button id="close-modal" class="bg-blue-500 text-white px-4 py-2 rounded mt-4">閉じる</button>
   </div>
 </div>
+

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -36,7 +36,7 @@
       </div>
     
       <div class="flex flex-col items-center">
-      <%= f.button :submit, class: "inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base" %>
+      <%= f.button (t 'defaults.register'), class: "inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base" %>
       </div>
       
     

--- a/db/migrate/20230424021728_create_monthly_achievements.rb
+++ b/db/migrate/20230424021728_create_monthly_achievements.rb
@@ -1,0 +1,12 @@
+class CreateMonthlyAchievements < ActiveRecord::Migration[7.0]
+  def change
+    create_table :monthly_achievements do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.integer :year
+      t.integer :month
+      t.integer :achieved_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_10_034218) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_24_021728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "monthly_achievements", force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.integer "year"
+    t.integer "month"
+    t.integer "achieved_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_monthly_achievements_on_user_id"
+  end
 
   create_table "morning_activity_logs", force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -50,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_10_034218) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "monthly_achievements", "users"
   add_foreign_key "morning_activity_logs", "start_time_plans", on_delete: :cascade
   add_foreign_key "morning_activity_logs", "users"
   add_foreign_key "posts", "users"

--- a/spec/factories/monthly_achievements.rb
+++ b/spec/factories/monthly_achievements.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: monthly_achievements
+#
+#  id             :bigint           not null, primary key
+#  achieved_count :integer
+#  month          :integer
+#  year           :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :uuid             not null
+#
+# Indexes
+#
+#  index_monthly_achievements_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :monthly_achievement do
+    user { nil }
+    year { 1 }
+    month { 1 }
+    achieved_count { 1 }
+  end
+end

--- a/spec/models/monthly_achievement_spec.rb
+++ b/spec/models/monthly_achievement_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: monthly_achievements
+#
+#  id             :bigint           not null, primary key
+#  achieved_count :integer
+#  month          :integer
+#  year           :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :uuid             not null
+#
+# Indexes
+#
+#  index_monthly_achievements_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe MonthlyAchievement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

issue番号 #68 

## 確認方法
- [ ] bin/dev
- [ ] localhost:3000にアクセス
- [ ] ログイン→morning_activity_logs画面へ遷移
- [ ] 目標朝活開始時刻で時刻を設定
- [ ] 更新（もしくは「設定する」）→ morning_activity_logs画面へ遷移
- [ ] 朝活開始ボタンを押下
- [ ] モーダル表示