### PR TITLE
新しい月に達成カウントが0スタートになる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,3 +98,6 @@ end
 gem 'dockerfile-rails', '>= 1.2', group: :development
 
 gem 'redis', '~> 5.0'
+
+# Gemfile
+gem 'timecop', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,7 @@ GEM
     tailwindcss-rails (2.0.24-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
+    timecop (0.9.6)
     timeout (0.3.2)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
+  timecop
   turbo-rails
   tzinfo-data
   web-console

--- a/app/controllers/morning_activity_logs_controller.rb
+++ b/app/controllers/morning_activity_logs_controller.rb
@@ -7,7 +7,7 @@ class MorningActivityLogsController < ApplicationController
     @morning_activity_logs = current_user.morning_activity_logs.includes(:start_time_plan)
     @morning_activity_not_allowed = MorningActivityLog.is_morning_activity_not_allowed?(current_user)
     @previous_achieved_count = [(params[:previous_achieved_count] || MorningActivityLog.current_monthly_achievement(current_user).achieved_count || DEFAULT_ACHIEVED_COUNT).to_i, DEFAULT_ACHIEVED_COUNT].max
-    @achieved_count = [(params[:achieved_count] || MorningActivityLog.current_monthly_achievement(current_user).achieved_count || DEFAULT_ACHIEVED_COUNT).to_i, DEFAULT_ACHIEVED_COUNT].max
+    @achieved_count = [(params[:achieved_count] || MonthlyAchievement.achieved_count_or_default(current_user.id, Time.current.year, Time.current.month)).to_i, DEFAULT_ACHIEVED_COUNT].max
   end
   
   def create

--- a/app/models/monthly_achievement.rb
+++ b/app/models/monthly_achievement.rb
@@ -29,6 +29,13 @@ class MonthlyAchievement < ApplicationRecord
     user.monthly_achievements.create!(year: Time.current.year, month: Time.current.month, achieved_count: DEFAULT_ACHIEVED_COUNT)
   end
 
+  #翌月の朝活達成カウント(achieved_count)の値がnil?を返さないようにするために、nilだった場合、デフォルト値０を設定するメソッド
+  def self.achieved_count_or_default(user_id, year, month)
+    monthly_achievement = find_by(user_id: user_id, year: year, month: month)  
+    monthly_achievement&.achieved_count || DEFAULT_ACHIEVED_COUNT
+  end
+  
+
 # achieved_count に nil が入らないように設定。値が無い場合、to_i メソッドで 0 を返す。加算時には +1 される。
 def increment_achieved_count
     self.achieved_count = achieved_count.to_i + INCREMENT_VALUE

--- a/app/models/monthly_achievement.rb
+++ b/app/models/monthly_achievement.rb
@@ -20,8 +20,14 @@
 #
 class MonthlyAchievement < ApplicationRecord
   belongs_to :user
+  # 以下は、達成回数に関する定数を設定しています。
+  DEFAULT_ACHIEVED_COUNT = 0
   INCREMENT_VALUE = 1
   
+  #新しい月の達成回数（achieved_count）は0で初期化される
+  def self.initialize_new_month(user)
+    user.monthly_achievements.create!(year: Time.current.year, month: Time.current.month, achieved_count: DEFAULT_ACHIEVED_COUNT)
+  end
 
 # achieved_count に nil が入らないように設定。値が無い場合、to_i メソッドで 0 を返す。加算時には +1 される。
 def increment_achieved_count


### PR DESCRIPTION
## 概要

issue 番号 #69 

## 確認方法
achieved_countが自動的に0からスタートする仕組みが実現されているかどうかを証明するために、以下の手順を実行できます。

- [ ] 現在の月の末日に、朝活ログを作成してください。これは、新しい月のデータが存在しない状態を作るためです。

- [ ] 翌月の初日に、新しい朝活ログを作成してください。この操作により、MorningActivityLogモデルのafter_createコールバックが呼び出され、initialize_new_month_if_neededメソッドが実行されます。

- [ ] initialize_new_month_if_neededメソッドが実行されると、現在の年と月に対応するMonthlyAchievementレコードが存在しないことが確認されます。そのため、initialize_new_month(user)メソッドが呼び出され、新しいMonthlyAchievementレコードが作成され、achieved_countが0で初期化されます。

- [ ] 新しい月の朝活ログ一覧ページ（MorningActivityLogsControllerのindexアクション）にアクセスしてください。achieved_countはMonthlyAchievement.achieved_count_or_default(current_user.id, Time.current.year, Time.current.month)メソッドを使用して取得されます。このメソッドは、存在しない場合でもデフォルト値0を返すように設計されています。

- [ ] 朝活ログ一覧ページに表示されるachieved_countが0であることを確認してください。これは、新しい月が始まり、achieved_countが自動的に0からスタートする仕組みが実現されていることを示します。

これらの手順により、achieved_countが自動的に0からスタートする仕組みが実現されていることを証明できます。