### PR TITLE
Googleアナリティクス測定ID再発行-非公開キー設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,13 +14,13 @@
 
 </head>
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-8DGR1BX5G2"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ANALYTICS_MEASUREMENT_ID'] %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-8DGR1BX5G2');
+  gtag('config', '<%= ENV['GOOGLE_ANALYTICS_MEASUREMENT_ID'] %>');
 </script>
   <body>
     <%= render logged_in? ? 'shared/header' : 'shared/before_login_header' %>


### PR DESCRIPTION
## 概要
Googleアナリティクス測定ID再発行-非公開キー設定
