### PR TITLE
Feature/target start time change limit

### DIFF
--- a/app/controllers/start_time_plans_controller.rb
+++ b/app/controllers/start_time_plans_controller.rb
@@ -18,10 +18,22 @@ class StartTimePlansController < ApplicationController
 
   def update
     @start_time_plan = current_user.start_time_plan
+
+    # この月の開始時間を既に3回更新したかどうかを確認
+    if @start_time_plan.exceeded_monthly_updates?
+      flash[:error] = t('.update_limit')
+      redirect_to morning_activity_logs_path # あるいは適切なパス
+      return
+    end
+
     if @start_time_plan.update(start_time_plan_params)
-      redirect_to morning_activity_logs_path, success: t('.success')
+      # 月の更新回数を増やす
+      @start_time_plan.increment!(:monthly_updates_count)
+      
+      redirect_to morning_activity_logs_path,  success: t('.success')
     else
-      render :edit
+      flash.now[:error] = t('.fail')
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/start_time_plan_helper.rb
+++ b/app/helpers/start_time_plan_helper.rb
@@ -1,0 +1,7 @@
+module StartTimePlanHelper
+    MINIMUM_UPDATES_COUNT = 0
+  
+    def confirmation_message(start_time_plan)
+      start_time_plan.remaining_updates > MINIMUM_UPDATES_COUNT ? "return confirm('今月は残り#{start_time_plan.remaining_updates}回まで更新可能ですがよろしいですか？');" : ""
+    end
+  end

--- a/app/models/start_time_plan.rb
+++ b/app/models/start_time_plan.rb
@@ -2,11 +2,12 @@
 #
 # Table name: start_time_plans
 #
-#  id         :bigint           not null, primary key
-#  start_time :datetime         not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id                    :bigint           not null, primary key
+#  monthly_updates_count :integer          default(0)
+#  start_time            :datetime         not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :uuid             not null
 #
 # Indexes
 #
@@ -23,17 +24,26 @@ class StartTimePlan < ApplicationRecord
 
   ALLOWED_START_HOUR = 4
   ALLOWED_END_HOUR = 10
+  MAX_UPDATES_PER_MONTH = 3 # 1ヶ月に更新できる回数
+
+  def remaining_updates #残り更新回数
+    MAX_UPDATES_PER_MONTH - monthly_updates_count #目標開始時刻の月の上限更新回数-目標開始時刻の月の更新回数
+  end
+
+  def exceeded_monthly_updates? #目標開始時刻の月の上限更新回数を超えたか
+    monthly_updates_count >= MAX_UPDATES_PER_MONTH #目標開始時刻の月の更新回数が目標開始時刻の月の上限更新回数以上か
+  end
 
   private
 
-  def start_time_within_allowed_range
-    return if start_time.blank?
+  def start_time_within_allowed_range #目標開始時刻が許容範囲内か
+    return if start_time.blank? #目標開始時刻が空白ならば
 
-    allowed_start_time = ALLOWED_START_HOUR.hours
-    allowed_end_time = ALLOWED_END_HOUR.hours
+    allowed_start_time = ALLOWED_START_HOUR.hours #許容開始時刻
+    allowed_end_time = ALLOWED_END_HOUR.hours #許容終了時刻
 
-    return if start_time.seconds_since_midnight.between?(allowed_start_time, allowed_end_time)
+    return if start_time.seconds_since_midnight.between?(allowed_start_time, allowed_end_time) #目標開始時刻が許容開始時刻と許容終了時刻の間ならば
 
-    errors.add(:start_time, :not_within_allowed_range)
+    errors.add(:start_time, :not_within_allowed_range) #目標開始時刻が許容範囲内でないとエラー
   end
 end

--- a/app/views/start_time_plans/edit.html.erb
+++ b/app/views/start_time_plans/edit.html.erb
@@ -2,14 +2,17 @@
   <div class="container mx-auto px-4 h-full">
     <div class="flex content-center items-center justify-center h-full">
       <div class="hero-content flex-col">
-        <%= form_with(model: @start_time_plan, local: true) do |f| %>
-          <div class="flex flex-col gap-4 p-4 md:p-8">
+      <%= form_with(model: @start_time_plan, local: true) do |f| %>
+        <div class="flex flex-col gap-4 p-4 md:p-8">
           <%= render 'form' , start_time_plan: @start_time_plan, f: f%>
-          </div>
-          <div class="flex flex-col items-center">
-          <%= f.submit '更新', class: 'btn btn-primary inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base' %>
-          </div>
-        <% end %>
+        </div>
+        <div class="flex flex-col items-center">
+        <%= f.submit '更新', 
+             class: 'btn btn-primary inline-block rounded-lg bg-indigo-500 px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:bg-indigo-600 focus-visible:ring active:bg-indigo-700 md:text-base',
+             onclick: confirmation_message(@start_time_plan) %>
+
+      <% end %>
+      
       </div>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -68,6 +68,7 @@ ja:
     update: 
       success: 目標朝活開始時刻を更新しました
       fail: 目標朝活開始時刻更新に失敗しました
+      update_limit: 目標開始時刻の更新は月に3回までです。
   morning_activity_logs:
       create:
         success: 朝活を開始しました

--- a/db/migrate/20230705100004_add_monthly_updates_count_to_start_time_plans.rb
+++ b/db/migrate/20230705100004_add_monthly_updates_count_to_start_time_plans.rb
@@ -1,0 +1,5 @@
+class AddMonthlyUpdatesCountToStartTimePlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :start_time_plans, :monthly_updates_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_20_125331) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_100004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_20_125331) do
     t.datetime "start_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "monthly_updates_count", default: 0
     t.index ["user_id"], name: "index_start_time_plans_on_user_id"
   end
 

--- a/lib/tasks/reset_monthly_updates_count.rake
+++ b/lib/tasks/reset_monthly_updates_count.rake
@@ -1,0 +1,6 @@
+namespace :start_time_plan do
+    desc "Reset monthly_updates_count for all StartTimePlan records"
+    task reset_monthly_updates_count: :environment do
+      StartTimePlan.update_all(monthly_updates_count: 0)
+    end
+  end

--- a/lib/tasks/reset_monthly_updates_count.rake
+++ b/lib/tasks/reset_monthly_updates_count.rake
@@ -1,6 +1,11 @@
 namespace :start_time_plan do
-    desc "Reset monthly_updates_count for all StartTimePlan records"
+    FIRST_DAY_OF_MONTH = 1
+  
+    desc "Reset monthly_updates_count for all start_time_plan"
     task reset_monthly_updates_count: :environment do
-      StartTimePlan.update_all(monthly_updates_count: 0)
+      if Date.today.day == FIRST_DAY_OF_MONTH
+        StartTimePlan.update_all(monthly_updates_count: 0)
+      end
     end
   end
+  

--- a/spec/factories/start_time_plans.rb
+++ b/spec/factories/start_time_plans.rb
@@ -2,11 +2,12 @@
 #
 # Table name: start_time_plans
 #
-#  id         :bigint           not null, primary key
-#  start_time :datetime         not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id                    :bigint           not null, primary key
+#  monthly_updates_count :integer          default(0)
+#  start_time            :datetime         not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/start_time_plan_spec.rb
+++ b/spec/models/start_time_plan_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: start_time_plans
 #
-#  id         :bigint           not null, primary key
-#  start_time :datetime         not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :uuid             not null
+#  id                    :bigint           not null, primary key
+#  monthly_updates_count :integer          default(0)
+#  start_time            :datetime         not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :uuid             not null
 #
 # Indexes
 #


### PR DESCRIPTION
## 概要
issue #141 


## 確認方法
目標開始時刻の上限回数を設定
目標開始時刻を変更の際に、確認ダイアログが表示

## 目標開始時刻のrakeタスク実行コマンド

```
rake start_time_plan:reset_monthly_updates_count
```

```
heroku run rake start_time_plan:reset_monthly_updates_count --app ohalog
```